### PR TITLE
Fixing memcpy signature to match the expected argument order + fix to…

### DIFF
--- a/docs/lesson05/rpi-os.md
+++ b/docs/lesson05/rpi-os.md
@@ -234,7 +234,7 @@ int copy_process(unsigned long clone_flags, unsigned long fn, unsigned long arg,
         p->cpu_context.x20 = arg;
     } else {
         struct pt_regs * cur_regs = task_pt_regs(current);
-        *cur_regs = *childregs;
+        *childregs = *cur_regs;
         childregs->regs[0] = 0;
         childregs->sp = stack + PAGE_SIZE; 
         p->stack = stack;
@@ -258,7 +258,7 @@ In case, when we are creating a new kernel thread, the function behaves exactly 
 
 ```
         struct pt_regs * cur_regs = task_pt_regs(current);
-        *cur_regs = *childregs;
+        *childregs = *cur_regs;
         childregs->regs[0] = 0;
         childregs->sp = stack + PAGE_SIZE; 
         p->stack = stack;

--- a/docs/lesson06/rpi-os.md
+++ b/docs/lesson06/rpi-os.md
@@ -399,7 +399,7 @@ int move_to_user_mode(unsigned long start, unsigned long size, unsigned long pc)
     if (code_page == 0)    {
         return -1;
     }
-    memcpy(start, code_page, size);
+    memcpy(code_page, start, size);
     set_pgd(current->mm.pgd);
     return 0;
 }
@@ -435,7 +435,7 @@ We made a simple convention that our user program will not exceed 1 page in size
 `allocate_user_page` reserves 1  memory page and maps it to the virtual address, provided as a second argument. In the process of mapping it populates page tables, associated with the current process. We will investigate in details how this function works later in this chapter.
 
 ```
-    memcpy(start, code_page, size);
+    memcpy(code_page, start, size);
 ```
 
 Next, we copy the whole user region to the page that we have just mapped. 
@@ -629,7 +629,7 @@ int copy_virt_memory(struct task_struct *dst) {
         if( kernel_va == 0) {
             return -1;
         }
-        memcpy(src->mm.user_pages[i].virt_addr, kernel_va, PAGE_SIZE);
+        memcpy(kernel_va, src->mm.user_pages[i].virt_addr, PAGE_SIZE);
     }
     return 0;
 }

--- a/src/lesson05/src/fork.c
+++ b/src/lesson05/src/fork.c
@@ -24,7 +24,7 @@ int copy_process(unsigned long clone_flags, unsigned long fn, unsigned long arg,
 		p->cpu_context.x20 = arg;
 	} else {
 		struct pt_regs * cur_regs = task_pt_regs(current);
-		*cur_regs = *childregs;
+		*childregs = *cur_regs;
 		childregs->regs[0] = 0;
 		childregs->sp = stack + PAGE_SIZE; 
 		p->stack = stack;

--- a/src/lesson05/src/mm.S
+++ b/src/lesson05/src/mm.S
@@ -1,7 +1,7 @@
 .globl memcpy
 memcpy:
-	ldr x3, [x0], #8
-	str x3, [x1], #8
+	ldr x3, [x1], #8
+	str x3, [x0], #8
 	subs x2, x2, #8
 	b.gt memcpy
 	ret

--- a/src/lesson06/include/mm.h
+++ b/src/lesson06/include/mm.h
@@ -37,7 +37,7 @@ unsigned long get_free_page();
 void free_page(unsigned long p);
 void map_page(struct task_struct *task, unsigned long va, unsigned long page);
 void memzero(unsigned long src, unsigned long n);
-void memcpy(unsigned long src, unsigned long dst, unsigned long n);
+void memcpy(unsigned long dst, unsigned long src, unsigned long n);
 
 int copy_virt_memory(struct task_struct *dst); 
 unsigned long allocate_kernel_page(); 

--- a/src/lesson06/src/fork.c
+++ b/src/lesson06/src/fork.c
@@ -21,7 +21,7 @@ int copy_process(unsigned long clone_flags, unsigned long fn, unsigned long arg)
 		p->cpu_context.x20 = arg;
 	} else {
 		struct pt_regs * cur_regs = task_pt_regs(current);
-		*cur_regs = *childregs;
+		*childregs = *cur_regs;
 		childregs->regs[0] = 0;
 		copy_virt_memory(p);
 	}
@@ -51,7 +51,7 @@ int move_to_user_mode(unsigned long start, unsigned long size, unsigned long pc)
 	if (code_page == 0)	{
 		return -1;
 	}
-	memcpy(start, code_page, size);
+	memcpy(code_page, start, size);
 	set_pgd(current->mm.pgd);
 	return 0;
 }

--- a/src/lesson06/src/mm.S
+++ b/src/lesson06/src/mm.S
@@ -1,7 +1,7 @@
 .globl memcpy
 memcpy:
-	ldr x3, [x0], #8
-	str x3, [x1], #8
+	ldr x3, [x1], #8
+	str x3, [x0], #8
 	subs x2, x2, #8
 	b.gt memcpy
 	ret

--- a/src/lesson06/src/mm.c
+++ b/src/lesson06/src/mm.c
@@ -91,7 +91,7 @@ int copy_virt_memory(struct task_struct *dst) {
 		if( kernel_va == 0) {
 			return -1;
 		}
-		memcpy(src->mm.user_pages[i].virt_addr, kernel_va, PAGE_SIZE);
+		memcpy(kernel_va, src->mm.user_pages[i].virt_addr, PAGE_SIZE);
 	}
 	return 0;
 }


### PR DESCRIPTION
From the [memcpy man pages](http://man7.org/linux/man-pages/man3/memcpy.3.html), the method signature is

```
void *memcpy(void *dest, const void *src, size_t n);
```

However, in [the code](https://github.com/s-matyukevich/raspberry-pi-os/blob/master/src/lesson06/include/mm.h#L40), the signature is backward (`src` is the first argument). This is the reason why [this issue](https://github.com/s-matyukevich/raspberry-pi-os/issues/111) was showing up.

I updated all code examples (that I could find) but I didn't update the exercises. 