### PR TITLE
Update rpi-os.md

### DIFF
--- a/docs/lesson02/rpi-os.md
+++ b/docs/lesson02/rpi-os.md
@@ -41,7 +41,7 @@ Here we use `mrs` instruction to read the value from `CurrentEL` system register
     printf("Exception level: %d \r\n", el);
 ```
 
-If you reproduce this experiment, you should see `Exception level: 3` on the screen.
+If you reproduce this experiment, you should see `Exception level: 2` on the screen.
 
 ### Changing current exception level
 


### PR DESCRIPTION
Hello,
First of all thanks for this wonderful tutorial! I'm really enjoying it!
I was reading [this](https://github.com/s-matyukevich/raspberry-pi-os/blob/master/docs/lesson02/rpi-os.md#finding-current-exception-level) and I think the print at the end of the paragraph, should say `Exception level: 2` and not `3`. According to what's written in the previous paragraph of that page, the kernel initially runs at EL 2 aka Hypervisor, and doesn't mention at all EL3.
Feel free to close this if I'm wrong.
