### PR TITLE
Fix broken link to ARMv8-A Programmer's Guide

### DIFF
--- a/docs/lesson01/rpi-os.md
+++ b/docs/lesson01/rpi-os.md
@@ -223,7 +223,7 @@ For those of you who are not familiar with ARM assembler syntax, let me quickly 
 * [**bl**](http://www.keil.com/support/man/docs/armasm/armasm_dom1361289865686.htm) "Branch with a link": perform an unconditional branch and store the return address in x30 (the link register). When the subroutine is finished, use the `ret` instruction to jump back to the return address.
 * [**mov**](http://www.keil.com/support/man/docs/armasm/armasm_dom1361289878994.htm) Move a value between registers or from a constant to a register.
 
-[Here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.den0024a/index.html) is the ARMv8-A developer's guide. It's a good resource if the ARM ISA is unfamiliar to you. [This page](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.den0024a/ch09s01s01.html) specifically outlines the register usage convention in the ABI.
+[Here](https://developer.arm.com/documentation/den0024/a) is the ARMv8-A developer's guide. It's a good resource if the ARM ISA is unfamiliar to you. [This page](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.den0024a/ch09s01s01.html) specifically outlines the register usage convention in the ABI.
 
 ### The `kernel_main` function
 


### PR DESCRIPTION
It looks like they changed the URL format.

* This is now a broken link: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.den0024a/index.html 
* This seems to be the new format: https://developer.arm.com/documentation/den0024/a
