### PR TITLE
Update rpi-os.md to refer mm.S file for memzero

### DIFF
--- a/docs/lesson01/rpi-os.md
+++ b/docs/lesson01/rpi-os.md
@@ -203,7 +203,7 @@ master:
     bl     memzero
 ```
 
-Here, we clean the `.bss` section by calling `memzero`. We will define this function later. In ARMv8 architecture, by convention, the first seven arguments are passed to the called function via registers x0–x6. The `memzero` function accepts only two arguments: the start address (`bss_begin`) and the size of the section needed to be cleaned (`bss_end - bss_begin`).
+Here, we clean the `.bss` section by calling `memzero`. We will define this function later. You can check the implementation of `memzero` in the [mm.S](https://github.com/s-matyukevich/raspberry-pi-os/blob/master/src/lesson01/src/mm.S) file. In ARMv8 architecture, by convention, the first seven arguments are passed to the called function via registers x0–x6. The `memzero` function accepts only two arguments: the start address (`bss_begin`) and the size of the section needed to be cleaned (`bss_end - bss_begin`).
 
 ```
     mov    sp, #LOW_MEMORY


### PR DESCRIPTION
I was confused about what is `memzero`, googled but couldn't find anything. Didn't know that it is a custom implementation in this repository. So I'll just add this reference to mm.S file to prevent similar confusion from happening, so that reader know that the memzero is a custom implementation which they can find in this repo.