### PR TITLE
added 1 to 1 memmap to avoid crash at mmu enable

### DIFF
--- a/src/lesson06/launch
+++ b/src/lesson06/launch
@@ -1,0 +1,1 @@
+qemu-system-aarch64 -machine raspi3b -cpu cortex-a53 -m 1G -smp 4 -serial null -serial mon:stdio -device loader,file=kernel8.img,addr=0

--- a/src/lesson06/src/boot.S
+++ b/src/lesson06/src/boot.S
@@ -7,17 +7,17 @@
 
 .globl _start
 _start:
-	mrs	x0, mpidr_el1		
+	mrs	x0, mpidr_el1
 	and	x0, x0,#0xFF		// Check processor id
 	cbz	x0, master		// Hang for all non-primary CPU
 	b	proc_hang
 
-proc_hang: 
+proc_hang:
 	b proc_hang
 
 master:
 	ldr	x0, =SCTLR_VALUE_MMU_DISABLED
-	msr	sctlr_el1, x0		
+	msr	sctlr_el1, x0
 
 	ldr	x0, =HCR_VALUE
 	msr	hcr_el2, x0
@@ -28,10 +28,10 @@ master:
 	ldr	x0, =SPSR_VALUE
 	msr	spsr_el3, x0
 
-	adr	x0, el1_entry		
+	adr	x0, el1_entry
 	msr	elr_el3, x0
 
-	eret				
+	eret
 
 el1_entry:
 	adr	x0, bss_begin
@@ -41,13 +41,16 @@ el1_entry:
 
 	bl 	__create_page_tables
 
-	mov	x0, #VA_START			
+	mov	x0, #VA_START
 	add	sp, x0, #LOW_MEMORY
 
-	adrp	x0, pg_dir				
+	adrp	x0, pg_dir_121
+	msr	ttbr0_el1, x0
+
+	adrp	x0, pg_dir
 	msr	ttbr1_el1, x0
 
-	ldr	x0, =(TCR_VALUE)		
+	ldr	x0, =(TCR_VALUE)
 	msr	tcr_el1, x0
 
 	ldr	x0, =(MAIR_VALUE)
@@ -56,7 +59,7 @@ el1_entry:
 
 	ldr	x2, =kernel_main
 
-	mov	x0, #SCTLR_MMU_ENABLED				
+	mov	x0, #SCTLR_MMU_ENABLED
 	msr	sctlr_el1, x0
 
 	br 	x2
@@ -70,7 +73,7 @@ el1_entry:
 	lsr	\tmp1, \virt, #\shift
 	and	\tmp1, \tmp1, #PTRS_PER_TABLE - 1			// table index
 	add	\tmp2, \tbl, #PAGE_SIZE
-	orr	\tmp2, \tmp2, #MM_TYPE_PAGE_TABLE	
+	orr	\tmp2, \tmp2, #MM_TYPE_PAGE_TABLE
 	str	\tmp2, [\tbl, \tmp1, lsl #3]
 	add	\tbl, \tbl, #PAGE_SIZE					// next level table page
 	.endm
@@ -93,12 +96,26 @@ el1_entry:
 __create_page_tables:
 	mov	x29, x30						// save return address
 
+	adrp	x0, pg_dir_121
+	mov	x1, #PG_DIR_SIZE
+	bl 	memzero
+
+	adrp	x0, pg_dir_121
+	mov	x1, #0
+	create_pgd_entry x0, x1, x2, x3
+
+	/* Mapping boot code*/
+	mov 	x1, xzr							// start mapping from physical offset 0
+	mov 	x2, #0							// first virtual address
+	ldr	x3, =(DEVICE_BASE - SECTION_SIZE)		// last virtual address
+	create_block_map x0, x1, x2, x3, MMU_FLAGS, x4
+
 	adrp	x0, pg_dir
 	mov	x1, #PG_DIR_SIZE
 	bl 	memzero
 
 	adrp	x0, pg_dir
-	mov	x1, #VA_START 
+	mov	x1, #VA_START
 	create_pgd_entry x0, x1, x2, x3
 
 	/* Mapping kernel and init stack*/
@@ -108,7 +125,7 @@ __create_page_tables:
 	create_block_map x0, x1, x2, x3, MMU_FLAGS, x4
 
 	/* Mapping device memory*/
-	mov 	x1, #DEVICE_BASE					// start mapping from device base address 
+	mov 	x1, #DEVICE_BASE					// start mapping from device base address
 	ldr 	x2, =(VA_START + DEVICE_BASE)				// first virtual address
 	ldr	x3, =(VA_START + PHYS_MEMORY_SIZE - SECTION_SIZE)	// last virtual address
 	create_block_map x0, x1, x2, x3, MMU_DEVICE_FLAGS, x4

--- a/src/lesson06/src/linker.ld
+++ b/src/lesson06/src/linker.ld
@@ -14,8 +14,11 @@ SECTIONS
 	.data : { *(.data) }
 	. = ALIGN(0x8);
 	bss_begin = .;
-	.bss : { *(.bss*) } 
+	.bss : { *(.bss*) }
 	bss_end = .;
+	. = ALIGN(0x00001000);
+	pg_dir_121 = .;
+	.data.pgd_121 : { . += (3 * (1 << 12)); }
 	. = ALIGN(0x00001000);
 	pg_dir = .;
 	.data.pgd : { . += (3 * (1 << 12)); }


### PR DESCRIPTION
Trying to run lesson06 on qemu crashed on the first instruction after  mmu enabled. Running raw code is missing a 1:1 pagetable when running with MMU. this patch adds a 'naive' memory map from from 0. 
Also a launch script is put in root dir of lesson06 to test the binary with qemu (linux).